### PR TITLE
Added httpError v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ provides a generic error handler that can be used at the "end" of your app
 
 Throws an error that has an HTTP status code. These errors are public-friendly, therefore their message can be displayed on the API.
 
+You may also customize the format of the error message. For example, if you want to send an object instead of a string, you need to add the object to the data attribute of the error object like so:
+
+```js
+  let err = utils.httpError(404);
+  err.data = {userMessage: 'This product was not found. Please try other products'}
+```
+Then on the client you will be able to do `err.userMessage`. 
+
 ``` js
   // if you are using the error handler above, you can do something like this in
   // any of your API endpoint

--- a/index.js
+++ b/index.js
@@ -33,9 +33,13 @@ function errorHandler(app) {
     if (app.get('env') == 'dev' && !err.statusCode) {
       throw err;
     }
-    err.message = err.statusCode ? err.message : 'Internal Server Error'
-    
-    res.status(err.statusCode || 500).send({message: err.message, userMessage: err.userMessage || ''});
+
+    if (err.data) {
+      res.status(err.statusCode || 500).send(err.data)
+      return
+    }
+
+    res.status(err.statusCode || 500).send({message: err.statusCode ? err.message : 'Internal Server Error'});
   });
 }
 
@@ -66,12 +70,9 @@ function getRouter(app, svc) {
  * an HTTP status code. These errors are public-friendly,
  * meaning their message can be displayed on the API.
  */
-function httpError(code = 500, message = http.STATUS_CODES[code], userMessage) {
+function httpError(code = 500, message = http.STATUS_CODES[code]) {
   let err = new Error(message);
   err.statusCode = code;
-  if (userMessage) {
-    err.userMessage = userMessage;
-  }
 
   return err;
 }

--- a/index.js
+++ b/index.js
@@ -33,8 +33,9 @@ function errorHandler(app) {
     if (app.get('env') == 'dev' && !err.statusCode) {
       throw err;
     }
-
-    res.status(err.statusCode || 500).send({message: err.statusCode ? err.message : 'Internal Server Error'});
+    err.message = err.statusCode ? err.message : 'Internal Server Error'
+    
+    res.status(err.statusCode || 500).send({message: err.message, userMessage: err.userMessage || ''});
   });
 }
 
@@ -65,9 +66,12 @@ function getRouter(app, svc) {
  * an HTTP status code. These errors are public-friendly,
  * meaning their message can be displayed on the API.
  */
-function httpError(code = 500, message = http.STATUS_CODES[code]) {
+function httpError(code = 500, message = http.STATUS_CODES[code], userMessage) {
   let err = new Error(message);
   err.statusCode = code;
+  if (userMessage) {
+    err.userMessage = userMessage;
+  }
 
   return err;
 }


### PR DESCRIPTION
We added an optional `userMessage` to the error object so that clients can easily handle and distinguish between errors that can be shown to the user and those that can't. 